### PR TITLE
:rocket: (env) filepath of gogole service account is constant

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
 # get the complete env from other volunteers, please
 BIGQUERY_PROJECT=pycontw-225217
 DATATEAM_DISCORD_WEBHOOK=<>
-GOOGLE_APPLICATION_CREDENTIALS=<>
+GOOGLE_APPLICATION_CREDENTIALS=/usr/local/airflow/service-account.json


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Bugfix**

## Description
<!--Describe what the change is**-->

no need to leave blank for `GOOGLE_APPLICATION_CREDENTIALS`, since we would always mount this account.json to the same filepath