### PR TITLE
<config>: remove auth and in favor of port-forwarding

### DIFF
--- a/airflow.cfg
+++ b/airflow.cfg
@@ -399,8 +399,8 @@ force_log_out_after = 0
 # The UI cookie lifetime in days
 session_lifetime_days = 30
 
-authenticate = True
-auth_backend = airflow.contrib.auth.backends.google_auth
+authenticate = False
+auth_backend = airflow.api.auth.backend.default
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Bugfix**
- 
## Description
<!--Describe what the change is**-->

we're using port-forward to login Airflow's web UI so no need to setup any auth. Google is taking over this chores for us.

