### PR TITLE
feat: add new dag for running mailer backfill jobs

### DIFF
--- a/dags/ods/kktix_ticket_orders/klaviyo_backfill_dag.py
+++ b/dags/ods/kktix_ticket_orders/klaviyo_backfill_dag.py
@@ -1,0 +1,36 @@
+"""
+Ingest KKTIX's daily data and load them to Mailer
+"""
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from ods.kktix_ticket_orders.udfs import batch_kktix2mailer
+
+DEFAULT_ARGS = {
+    "owner": "henry410213028@gmail.com",
+    "depends_on_past": False,
+    "start_date": datetime(2022, 7, 23),
+    "end_date": datetime(2022, 8, 25),
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": lambda x: "Need to send notification to Discord!",
+}
+dag = DAG(
+    "KLAVIYO_SEND_MAIL_BACKFILL_V1",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="0 23 * * *",
+    max_active_runs=1,
+    catchup=True,
+)
+with dag:
+    GET_ATTENDEE_INFOS = PythonOperator(
+        task_id="GET_ATTENDEE_INFOS",
+        python_callable=batch_kktix2mailer.main,
+        provide_context=True,
+    )
+
+    GET_ATTENDEE_INFOS
+
+if __name__ == "__main__":
+    dag.cli()

--- a/dags/ods/kktix_ticket_orders/klaviyo_backfill_dag.py
+++ b/dags/ods/kktix_ticket_orders/klaviyo_backfill_dag.py
@@ -11,7 +11,7 @@ DEFAULT_ARGS = {
     "owner": "henry410213028@gmail.com",
     "depends_on_past": False,
     "start_date": datetime(2022, 7, 23),
-    "end_date": datetime(2022, 8, 25),
+    "end_date": datetime(2022, 8, 29),
     "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": lambda x: "Need to send notification to Discord!",

--- a/dags/ods/kktix_ticket_orders/udfs/klaviyo_loader.py
+++ b/dags/ods/kktix_ticket_orders/udfs/klaviyo_loader.py
@@ -9,11 +9,13 @@ def _load_raw_data(event_raw_data_array: List) -> Iterable:
         attendee_info = event["attendee_info"]
         # search string contains personal information and it's unstructured. Therefore just drop it!
         del attendee_info["search_string"]
-        yield {
+        tmp = {
             key: value
             for index, (key, value) in enumerate(attendee_info["data"])
             if key in ("聯絡人 Email", "聯絡人 姓名")
         }
+        tmp.update({"qrcode": attendee_info["qrcode"]})
+        yield tmp
 
 
 def load(event_raw_data_array: List) -> None:
@@ -30,7 +32,7 @@ def load(event_raw_data_array: List) -> None:
         return
 
     datas = [
-        {"email": item["聯絡人 Email"], "name": item["聯絡人 姓名"]}
+        {"email": item["聯絡人 Email"], "name": item["聯絡人 姓名"], "qrcode": item["qrcode"]}
         for item in _load_raw_data(event_raw_data_array)
     ]
     if not datas:

--- a/dags/ods/kktix_ticket_orders/udfs/klaviyo_loader.py
+++ b/dags/ods/kktix_ticket_orders/udfs/klaviyo_loader.py
@@ -34,7 +34,7 @@ def load(event_raw_data_array: List) -> None:
         for item in _load_raw_data(event_raw_data_array)
     ]
     if not datas:
-        print("Skip klaviyo mailer, not user profiles")
+        print("Skip klaviyo mailer, no user profiles")
         return
 
     klaviyo_mailer.main(

--- a/tests/kktix_ticket_orders/test_klaviyo_loader.py
+++ b/tests/kktix_ticket_orders/test_klaviyo_loader.py
@@ -21,5 +21,11 @@ def test_klaviyo_loader(variable, mailer, kktix_api_data):
         list_id="abc",
         campaign_id="123",
         campaign_name="隨買即用",
-        datas=[{"email": "xxx@gmail.com", "name": "李xx"}],
+        datas=[
+            {
+                "email": "xxx@gmail.com",
+                "name": "李xx",
+                "qrcode": "bc7bd846f49d2d2e1g833cc92gdg2cf9",
+            }
+        ],
     )


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **New feature**

## Description

Uncomment mailer code and add a new DAG for running backfill jobs

@david30907d  I copy main logic from `./dags/ods/kktix_ticket_orders/udfs/kktix_api.py` and modify the schedule interval to daily, this task request user profiles from kktix API, then send un-hash data to mailer, and not reload data to bigquery.
