### PR TITLE
fix(ods): update linkedin DAG schedule to run every two days

### DIFF
--- a/dags/ods/linkedin_post_insights/dags.py
+++ b/dags/ods/linkedin_post_insights/dags.py
@@ -13,9 +13,9 @@ DEFAULT_ARGS = {
     "on_failure_callback": lambda x: "Need to send notification to Discord!",
 }
 dag = DAG(
-    "LINKEDIN_POST_INSIGHTS_V1",
+    "LINKEDIN_POST_INSIGHTS_V2",
     default_args=DEFAULT_ARGS,
-    schedule_interval="5 8 * * *",
+    schedule_interval="5 8 */2 * *",
     max_active_runs=1,
     catchup=False,
 )


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Others**

## Description
<!--Describe what the change is**-->

Due to freemium quota issue, change LinkedIn DAG schedule interval to run every two days.