### PR TITLE
chore: hardening pass — CI tests, error handling, configs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,5 @@ AIRFLOW_HOME=/opt/airflow
 BIGQUERY_PROJECT=pycontw-225217
 GOOGLE_APPLICATION_CREDENTIALS=/opt/airflow/service-account.json
 AIRFLOW__CORE__FERNET_KEY=paste-your-fernet-key-here
+# Airflow's docker entrypoint runs `airflow db migrate` on startup unless this is "false".
+_AIRFLOW_DB_MIGRATE=false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,11 +24,9 @@ jobs:
     - name: Build the Docker image
       run: |
         docker build -t ${RC_NAME}:cache --cache-from ${RC_NAME}:cache .
-        docker build -t ${RC_NAME}:test --cache-from ${RC_NAME}:cache -f Dockerfile.test .
-    - name: Run test
+    - name: Run tests inside the built image
       run: |
-        docker run -d --rm -p 8080:8080 --name airflow -v $(pwd)/dags:/opt/airflow/dags -v $(pwd)/fixtures:/opt/airflow/fixtures ${RC_NAME}:test webserver
-        sleep 10
+        make test-docker DOCKER_TEST_IMAGE=${RC_NAME}:test
     - name: Push cache to Google Container Registry
       if: success()
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,9 @@ default_install_hook_types:
 default_stages:
   - pre-commit
 
+auto_update:
+  cooldown_days: 4
+
 repos:
 - repo: local
   hooks:
@@ -32,3 +35,20 @@ repos:
           ^dags/fixtures/data_questionnaire.csv$
       additional_dependencies:
         - tomli
+
+- repo: local
+  hooks:
+    - id: make-format
+      name: make format (ruff check --fix + ruff format)
+      language: system
+      entry: make format
+      pass_filenames: false
+      always_run: true
+      types: [python]
+    - id: make-test
+      name: make test (pytest)
+      language: system
+      entry: make test
+      pass_filenames: false
+      always_run: true
+      types: [python]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Apache Airflow ETL system for PyCon Taiwan's data infrastructure. Manages event 
 ## Stack
 
 - **Airflow 3.x** — Python 3.10 (locked to <3.11), uv for dependency management
-- **BigQuery** — `pycontw-225217`; ODS layer for raw ingestion, DWD/DWS for future transforms
+- **BigQuery** — `pycontw-225217`; `ods.*` for raw ingestion, `dwd.*` for cleansed transforms (kktix attendees, user profiles). Transform code lives in-place under `dags/ods/.../udfs/`, not a separate package.
 - **SQLite** — intentional; this project is also used to test Airflow + SQLite compatibility
 - **Docker** — multi-service compose (API Server, DAG Processor, Scheduler, Triggerer)
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -38,6 +38,9 @@ ENV PYTHONPATH="${AIRFLOW_HOME}:$PYTHONPATH"
 
 COPY airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 COPY --chown=airflow:root dags ${AIRFLOW_HOME}/dags
+COPY --chown=airflow:root tests ${AIRFLOW_HOME}/tests
+COPY --chown=airflow:root contrib ${AIRFLOW_HOME}/contrib
+COPY --chown=airflow:root pyproject.toml ${AIRFLOW_HOME}/pyproject.toml
 
 ENV AIRFLOW_TEST_MODE=True
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ test:
 coverage:
 	uv run pytest --cov=dags tests
 
+DOCKER_TEST_IMAGE ?= pycon-etl:test
+
+test-docker:
+	docker build -t $(DOCKER_TEST_IMAGE) -f Dockerfile.test .
+	docker run --rm -w /opt/airflow --entrypoint pytest $(DOCKER_TEST_IMAGE)
+
 build-dev:
 	docker compose -f ./docker-compose-dev.yml build
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ test-docker:
 	docker build -t $(DOCKER_TEST_IMAGE) -f Dockerfile.test .
 	docker run --rm -w /opt/airflow --entrypoint pytest $(DOCKER_TEST_IMAGE)
 
+# Cooldown is configured in pyproject.toml (uv) and .pre-commit-config.yaml (prek >=0.3.12).
+upgrade:
+	uv lock --upgrade
+	uvx --from "prek>=0.3.12" prek auto-update
+
 build-dev:
 	docker compose -f ./docker-compose-dev.yml build
 

--- a/dags/app/twitter_post_notification_bot/dag.py
+++ b/dags/app/twitter_post_notification_bot/dag.py
@@ -37,33 +37,32 @@ def TWITTER_POST_NOTIFICATION_BOT_V2():
         response = requests.get(url, headers=headers, params=querystring)
         response_json = response.json()
         try:
-            variable_key = "TWITTER_LATEST_REST_ID"
-            rest_id = response_json["data"]["user"]["result"]["timeline_v2"][
+            timeline = response_json["data"]["user"]["result"]["timeline_v2"][
                 "timeline"
-            ]["instructions"][1]["entries"][0]["content"]["itemContent"][
-                "tweet_results"
-            ]["result"]["rest_id"]
-            full_text = response_json["data"]["user"]["result"]["timeline_v2"][
-                "timeline"
-            ]["instructions"][1]["entries"][0]["content"]["itemContent"][
-                "tweet_results"
-            ]["result"]["legacy"]["full_text"]
-            rest_id_in_DB = Variable.get(variable_key)
-            if rest_id_in_DB < rest_id:
-                Variable.set(variable_key, rest_id)
-
-                msg = f"new twitter post: https://twitter.com/PyConTW/status/{rest_id}\n\n{full_text}"
-                requests.post(
-                    url=webhook_url,
-                    json={"username": "Twitter Post Notification", "content": msg},
-                )
-        except Exception:
+            ]
+            latest_entry = timeline["instructions"][1]["entries"][0]
+            tweet = latest_entry["content"]["itemContent"]["tweet_results"]["result"]
+            rest_id = tweet["rest_id"]
+            full_text = tweet["legacy"]["full_text"]
+        except (KeyError, IndexError, TypeError):
             requests.post(
                 url=webhook_url,
                 json={
                     "username": "Twitter Post Notification",
                     "content": str(response_json),
                 },
+            )
+            return
+
+        variable_key = "TWITTER_LATEST_REST_ID"
+        rest_id_in_DB = Variable.get(variable_key)
+        if rest_id_in_DB < rest_id:
+            Variable.set(variable_key, rest_id)
+
+            msg = f"new twitter post: https://twitter.com/PyConTW/status/{rest_id}\n\n{full_text}"
+            requests.post(
+                url=webhook_url,
+                json={"username": "Twitter Post Notification", "content": msg},
             )
 
     SEND_TWITTER_POST_NOTIFICATION()

--- a/dags/ods/kktix_ticket_orders/udfs/kktix_api.py
+++ b/dags/ods/kktix_ticket_orders/udfs/kktix_api.py
@@ -6,12 +6,10 @@ import requests
 import tenacity
 from airflow.providers.http.hooks.http import HttpHook
 from airflow.sdk import Variable
-from dateutil.parser import parse
 from ods.kktix_ticket_orders.udfs import kktix_loader, kktix_transformer
 
 logger = logging.getLogger(__name__)
 
-SCHEDULE_INTERVAL_SECONDS: int = 3600
 HTTP_HOOK = HttpHook(http_conn_id="kktix_api", method="GET")
 RETRY_ARGS = dict(
     wait=tenacity.wait_none(),
@@ -24,15 +22,12 @@ def main(**context):
     """
     ETL pipeline should consists of extract, transform and load
     """
-    schedule_interval = context["dag"].schedule_interval
-    # If we change the schedule_interval, we need to update the logic in condition_filter_callback
-    assert schedule_interval == "50 * * * *"  # nosec
-    ts_datetime_obj = parse(context["ts"])
-    year = ts_datetime_obj.year
-    timestamp = ts_datetime_obj.timestamp()
+    interval_start = context["data_interval_start"]
+    interval_end = context["data_interval_end"]
     event_raw_data_array = _extract(
-        year=year,
-        timestamp=timestamp,
+        year=interval_start.year,
+        start_timestamp=interval_start.timestamp(),
+        end_timestamp=interval_end.timestamp(),
     )
     transformed_event_raw_data_array = kktix_transformer.transform(
         copy.deepcopy(event_raw_data_array)
@@ -46,11 +41,10 @@ def main(**context):
     )
 
 
-def _extract(year: int, timestamp: float) -> list[dict]:
+def _extract(year: int, start_timestamp: float, end_timestamp: float) -> list[dict]:
     """
     get data from KKTIX's API
-    1. condition_filter_callb: use this callback to filter out unwanted event!
-    2. right now schedule_interval_seconds is a hardcoded value!
+    1. condition_filter_callback: use this callback to filter out unwanted event!
     """
     event_raw_data_array: list[dict] = []
 
@@ -60,7 +54,9 @@ def _extract(year: int, timestamp: float) -> list[dict]:
     event_metadatas = get_event_metadatas(_condition_filter_callback)
     for event_metadata in event_metadatas:
         event_id = event_metadata["id"]
-        for attendee_info in get_attendee_infos(event_id, timestamp):
+        for attendee_info in get_attendee_infos(
+            event_id, start_timestamp, end_timestamp
+        ):
             event_raw_data_array.append(
                 {
                     "id": event_id,
@@ -71,13 +67,17 @@ def _extract(year: int, timestamp: float) -> list[dict]:
     return event_raw_data_array
 
 
-def get_attendee_infos(event_id: int, timestamp: float) -> list:
+def get_attendee_infos(
+    event_id: int, start_timestamp: float, end_timestamp: float
+) -> list:
     """
     it's a public wrapper for people to get attendee infos!
     """
     attendance_book_id = _get_attendance_book_id(event_id)
     attendee_ids = _get_attendee_ids(event_id, attendance_book_id)
-    attendee_infos = _get_attendee_infos(event_id, attendee_ids, timestamp)
+    attendee_infos = _get_attendee_infos(
+        event_id, attendee_ids, start_timestamp, end_timestamp
+    )
     return attendee_infos
 
 
@@ -122,15 +122,18 @@ def _get_attendee_ids(event_id: int, attendance_book_id: int) -> list[int]:
 
 
 def _get_attendee_infos(
-    event_id: int, attendee_ids: list[int], timestamp: float
+    event_id: int,
+    attendee_ids: list[int],
+    start_timestamp: float,
+    end_timestamp: float,
 ) -> list:
     """
     get attendee infos, e.g. email, phonenumber, name and etc
     """
     logger.info(
         "Fetching attendee infos between %s and %s",
-        timestamp,
-        timestamp + SCHEDULE_INTERVAL_SECONDS,
+        start_timestamp,
+        end_timestamp,
     )
     attendee_infos = []
     for attendee_id in attendee_ids:
@@ -140,10 +143,6 @@ def _get_attendee_infos(
         ).json()
         if not attendee_info["is_paid"]:
             continue
-        if (
-            timestamp
-            < attendee_info["updated_at"]
-            < timestamp + SCHEDULE_INTERVAL_SECONDS
-        ):
+        if start_timestamp < attendee_info["updated_at"] < end_timestamp:
             attendee_infos.append(attendee_info)
     return attendee_infos

--- a/dags/ods/kktix_ticket_orders/udfs/kktix_api.py
+++ b/dags/ods/kktix_ticket_orders/udfs/kktix_api.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 from collections.abc import Callable
 
 import requests
@@ -7,6 +8,8 @@ from airflow.providers.http.hooks.http import HttpHook
 from airflow.sdk import Variable
 from dateutil.parser import parse
 from ods.kktix_ticket_orders.udfs import kktix_loader, kktix_transformer
+
+logger = logging.getLogger(__name__)
 
 SCHEDULE_INTERVAL_SECONDS: int = 3600
 HTTP_HOOK = HttpHook(http_conn_id="kktix_api", method="GET")
@@ -35,7 +38,7 @@ def main(**context):
         copy.deepcopy(event_raw_data_array)
     )
     kktix_loader.load(transformed_event_raw_data_array)
-    print(f"Loaded {len(transformed_event_raw_data_array)} rows to BigQuery!")
+    logger.info("Loaded %d rows to BigQuery!", len(transformed_event_raw_data_array))
 
     # pass these unhashed data through xcom to next airflow task
     return kktix_transformer._extract_sensitive_unhashed_raw_data(
@@ -124,8 +127,10 @@ def _get_attendee_infos(
     """
     get attendee infos, e.g. email, phonenumber, name and etc
     """
-    print(
-        f"Fetching attendee infos between {timestamp} and {timestamp + SCHEDULE_INTERVAL_SECONDS}"
+    logger.info(
+        "Fetching attendee infos between %s and %s",
+        timestamp,
+        timestamp + SCHEDULE_INTERVAL_SECONDS,
     )
     attendee_infos = []
     for attendee_id in attendee_ids:

--- a/dags/ods/kktix_ticket_orders/udfs/kktix_bq_dwd_etl.py
+++ b/dags/ods/kktix_ticket_orders/udfs/kktix_bq_dwd_etl.py
@@ -668,7 +668,7 @@ def main():
     # res_clone = copy.copy(results)
     # print(res_clone)
 
-    print(f"Extracted from {TABLE}  successful.")
+    logging.info("Extracted from %s successful.", TABLE)
 
     # load to DataFrame for later bigquery upload from the extracted results
     df, sanitized_df = load_to_df_from_list(results, "bigquery", update_after_ts)
@@ -692,7 +692,7 @@ def main():
         logging.info("")
         logging.info("Column names (to-be):")
         logging.info(sanitized_df.columns)
-        print(sanitized_df.iloc[:, :5])
+        logging.info(sanitized_df.iloc[:, :5])
         # print(sanitized_df[['paid_date', 'payment_status', 'email']])
 
     return sanitized_df.columns

--- a/dags/ods/kktix_ticket_orders/udfs/kktix_loader.py
+++ b/dags/ods/kktix_ticket_orders/udfs/kktix_loader.py
@@ -1,9 +1,12 @@
 import json
+import logging
 import os
 
 import pandas as pd
 from google.cloud import bigquery
 from ods.kktix_ticket_orders.udfs import kktix_bq_dwd_etl
+
+logger = logging.getLogger(__name__)
 
 SCHEMA = [
     bigquery.SchemaField("id", "INTEGER", mode="REQUIRED"),
@@ -22,7 +25,7 @@ def load(event_raw_data_array: list):
     """
     # data quality check
     if len(event_raw_data_array) == 0:
-        print("Nothing to load, skip!")
+        logger.info("Nothing to load, skip!")
         return
     payload = []
     for event_raw_data in event_raw_data_array:

--- a/dags/ods/kktix_ticket_orders/udfs/kktix_refund.py
+++ b/dags/ods/kktix_ticket_orders/udfs/kktix_refund.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections import defaultdict
 from functools import cache
@@ -8,6 +9,8 @@ from ods.kktix_ticket_orders.udfs.kktix_api import (
     _get_attendance_book_id,
     _get_attendee_ids,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @cache
@@ -75,4 +78,4 @@ def _mark_tickets_as_refunded(refunded_attendee_ids: list[int]) -> None:
     """
     )
     result = query_job.result()
-    print(f"Result of _mark_tickets_as_refunded: {result}")
+    logger.info("Result of _mark_tickets_as_refunded: %s", result)

--- a/dags/ods/youtube/udfs/youtube_api.py
+++ b/dags/ods/youtube/udfs/youtube_api.py
@@ -88,7 +88,6 @@ def save_video_data_2_bq(**context):
                     "Cache-Control": "no-cache",
                 },
             ).json()
-            print(response_json["items"][0]["statistics"].keys())
             result.append(
                 (
                     execution_date,

--- a/dags/utils/posts_insights/base.py
+++ b/dags/utils/posts_insights/base.py
@@ -145,5 +145,5 @@ class BasePostsInsightsParser(ABC):
             )
             job.result()
         except Exception:
-            logger.exception(f"Failed to dump {dump_type} to BigQuery: ")
-            raise RuntimeError(f"Failed to dump {dump_type} to BigQuery")
+            logger.exception("Failed to dump %s to BigQuery", dump_type)
+            raise

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -85,7 +85,7 @@ services:
     command:
       - -c
       - |
-        if [[ -n "$${_AIRFLOW_DB_MIGRATE=}" ]]; then
+        if [[ "$${_AIRFLOW_DB_MIGRATE}" == "true" ]]; then
             airflow db migrate || true
         fi
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     command:
       - -c
       - |
-        if [[ -n "$${_AIRFLOW_DB_MIGRATE=}" ]]; then
+        if [[ "$${_AIRFLOW_DB_MIGRATE}" == "true" ]]; then
             airflow db migrate || true
         fi
     restart: "no"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ omit = ['env/*', 'venv/*', '*/virtualenv/*', '*/virtualenvs/*', '*/tests/*']
 
 [tool.uv]
 required-version = ">=0.9.17"
+exclude-newer = "4 days"
 # Synchroonize with scripts/ci/prek/upgrade_important_versions.py
 # airflow 3.2.1 constraint file for python 3.10
 # https://raw.githubusercontent.com/apache/airflow/refs/tags/constraints-3.2.1rc2/constraints-3.10.txt

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.10.*"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P4D"
+
 [manifest]
 constraints = [
     { name = "adbc-driver-manager", specifier = "==1.11.0" },


### PR DESCRIPTION
## Summary

- CI now runs pytest **inside the production-built image** (no more `sleep 10` letting broken images reach staging/prod)
- Replaced bare `except Exception` and stray `print()` calls so failures bubble to Airflow retries and logs respect levels
- `make upgrade` (uv + prek with 4-day cooldown) and an Airflow-native `data_interval` rewrite for the kktix schedule replace
fragile constants/assertions

## Commits

| | |
|---|---|
| `eff62c4` | `ci(docker)`: run pytest in the built image instead of a no-op sleep |
| `942296a` | `refactor`: narrow bare except clauses to preserve real failures |
| `4e2d317` | `refactor`: replace stray `print()` calls with logging |
| `54b28fe` | `chore`: configure 4-day release cooldown via uv and prek configs |
| `276807b` | `refactor(kktix)`: derive ingest window from Airflow `data_interval` |
| `14cb6e4` | `docs`: correct CLAUDE.md DWD claim |
| `17ac979` | `docs`: complete `.env.template` with `_AIRFLOW_DB_MIGRATE` |

## Test plan

- [x] `make lint` clean
- [x] `make test` — 15 tests pass
- [x] `make test-docker` — pytest passes inside the docker image
- [x] `uvx --from "prek>=0.3.12" prek run --all-files` — all hooks pass without warnings
- [x] CI green (`python.yml` + `dockerimage.yml`)