### PR TITLE
feat(ods): emit AssetAlias when new social media posts are found

### DIFF
--- a/dags/ods/fb_post_insights/dag.py
+++ b/dags/ods/fb_post_insights/dag.py
@@ -4,7 +4,7 @@ Scrape Facebook posts and insights data, save to BigQuery
 
 from datetime import datetime, timedelta
 
-from airflow.sdk import dag, task
+from airflow.sdk import AssetAlias, Metadata, dag, task
 from utils.posts_insights.facebook import FacebookPostsInsightsParser
 
 DEFAULT_ARGS = {
@@ -29,7 +29,8 @@ def FB_POST_INSIGHTS_V1():
 
     @task
     def SAVE_FB_POSTS_AND_INSIGHTS():
-        FacebookPostsInsightsParser().save_posts_and_insights()
+        if FacebookPostsInsightsParser().save_posts_and_insights():
+            yield Metadata(AssetAlias("new_social_media_post"))
 
     CREATE_TABLE_IF_NEEDED() >> SAVE_FB_POSTS_AND_INSIGHTS()
 

--- a/dags/ods/ig_post_insights/dags.py
+++ b/dags/ods/ig_post_insights/dags.py
@@ -4,7 +4,7 @@ Scrape Instagram posts and insights data, save to BigQuery
 
 from datetime import datetime, timedelta
 
-from airflow.sdk import dag, task
+from airflow.sdk import AssetAlias, Metadata, dag, task
 from utils.posts_insights.instagram import InstagramPostsInsightsParser
 
 DEFAULT_ARGS = {
@@ -29,7 +29,8 @@ def IG_POST_INSIGHTS_V1():
 
     @task
     def SAVE_IG_POSTS_AND_INSIGHTS():
-        InstagramPostsInsightsParser().save_posts_and_insights()
+        if InstagramPostsInsightsParser().save_posts_and_insights():
+            yield Metadata(AssetAlias("new_social_media_post"))
 
     CREATE_TABLE_IF_NEEDED() >> SAVE_IG_POSTS_AND_INSIGHTS()
 

--- a/dags/ods/linkedin_post_insights/dags.py
+++ b/dags/ods/linkedin_post_insights/dags.py
@@ -4,7 +4,7 @@ Scrape LinkedIn posts and insights data, save to BigQuery
 
 from datetime import datetime, timedelta
 
-from airflow.sdk import dag, task
+from airflow.sdk import AssetAlias, Metadata, dag, task
 from utils.posts_insights.linkedin import LinkedinPostsInsightsParser
 
 DEFAULT_ARGS = {
@@ -29,7 +29,8 @@ def LINKEDIN_POST_INSIGHTS_V2():
 
     @task
     def SAVE_LINKEDIN_POSTS_AND_INSIGHTS():
-        LinkedinPostsInsightsParser().save_posts_and_insights()
+        if LinkedinPostsInsightsParser().save_posts_and_insights():
+            yield Metadata(AssetAlias("new_social_media_post"))
 
     CREATE_TABLE_IF_NEEDED() >> SAVE_LINKEDIN_POSTS_AND_INSIGHTS()
 

--- a/dags/ods/twitter_post_insights/dags.py
+++ b/dags/ods/twitter_post_insights/dags.py
@@ -4,7 +4,7 @@ Scrape X (Twitter) posts and insights data, save to BigQuery
 
 from datetime import datetime, timedelta
 
-from airflow.sdk import dag, task
+from airflow.sdk import AssetAlias, Metadata, dag, task
 from utils.posts_insights.twitter import TwitterPostsInsightsParser
 
 DEFAULT_ARGS = {
@@ -29,7 +29,8 @@ def TWITTER_POST_INSIGHTS_V1():
 
     @task
     def SAVE_TWITTER_POSTS_AND_INSIGHTS():
-        TwitterPostsInsightsParser().save_posts_and_insights()
+        if TwitterPostsInsightsParser().save_posts_and_insights():
+            yield Metadata(AssetAlias("new_social_media_post"))
 
     CREATE_TABLE_IF_NEEDED() >> SAVE_TWITTER_POSTS_AND_INSIGHTS()
 

--- a/dags/utils/posts_insights/base.py
+++ b/dags/utils/posts_insights/base.py
@@ -50,7 +50,7 @@ class BasePostsInsightsParser(ABC):
         for sql in [self.CREATE_POSTS_TABLE_SQL, self.CREATE_INSIGHTS_TABLE_SQL]:
             self.bq_client.query(sql)
 
-    def save_posts_and_insights(self) -> None:
+    def save_posts_and_insights(self) -> int:
         posts = self._request_posts_data()
         last_post = self._query_last_post()
         new_posts = (
@@ -62,6 +62,8 @@ class BasePostsInsightsParser(ABC):
 
         posts_insights_data = self._process_posts_insights(posts)
         self._dump_posts_insights_to_bigquery(posts_insights_data)
+
+        return len(new_posts)
 
     @abstractmethod
     def _request_posts_data(self) -> list[dict]: ...


### PR DESCRIPTION
When FB/IG/LinkedIn/Twitter ODS Dags ingest new posts (detected by the existing _filter_new_posts logic in BasePostsInsightsParser), they now emit AssetAlias("new_social_media_post"). A future blog-publishing Dag can schedule on Asset(name="new_social_media_post") to trigger only when new content actually arrives.

base.save_posts_and_insights() now returns int (new post count) so callers can make the conditional emit decision without re-querying BigQuery.

<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Bugfix**
- **New feature**
- **Refactoring**
- **Breaking change** (any change that would cause existing functionality to not work as expected)
- **Documentation Update**
- **Other (please describe)**

## Description
<!--Describe what the change is**-->

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `make lint` and `make test` locally to ensure all linter checks and testing pass
- [ ] Update the documentation if necessary

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->

## Expected behavior
<!--A clear and concise description of what you expected to happen-->

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
